### PR TITLE
Webpack build flow v2

### DIFF
--- a/make-webpack-config.js
+++ b/make-webpack-config.js
@@ -19,7 +19,31 @@ module.exports = function(options) {
     filename: options.outputFilename
   };
 
+  var plugins = [];
 
+  if (options.useDevServer) {
+    plugins.push(new webpack.HotModuleReplacementPlugin());
+  }
+
+  if (options.minimize) {
+    plugins.push(
+      new webpack.optimize.UglifyJsPlugin({
+        compressor: {
+          warnings: false
+        }
+      }),
+      new webpack.optimize.DedupePlugin()
+    );
+
+    plugins.push(
+      new webpack.DefinePlugin({
+        "process.env": {
+          NODE_ENV: JSON.stringify("production")
+        }
+      }),
+      new webpack.NoErrorsPlugin()
+    );
+  }
 
   return {
     entry: entry,
@@ -31,6 +55,7 @@ module.exports = function(options) {
       extensions: ['', '.js', '.jsx']
     },
     output: output,
+    plugins: plugins,
 
     devServer: (options.useDevServer) ? {
       contentBase: './dist',
@@ -38,6 +63,5 @@ module.exports = function(options) {
     } : {},
 
     devtool: (options.sourcemaps) ? 'cheap-module-eval-source-map' : '',
-    plugins: (options.useDevServer) ? [new webpack.HotModuleReplacementPlugin()] : []
   };
 };

--- a/make-webpack-config.js
+++ b/make-webpack-config.js
@@ -1,0 +1,43 @@
+var webpack = require('webpack');
+
+// NOTE: this file is super derpy derpy; do not copy if you want something proper
+
+module.exports = function(options) {
+  // entry file
+  var entry = [];
+  entry = entry.concat(options.entryItems).concat(['./src/index.jsx']);
+
+  var basicLoader = {
+    test: /\.jsx?$/,
+    exclude: /node_modules/,
+    loader: options.loaderType
+  };
+
+  var output = {
+    path: __dirname + '/dist',
+    publicPath: '/',
+    filename: options.outputFilename
+  };
+
+
+
+  return {
+    entry: entry,
+    output: output,
+    module: {
+      loaders: [basicLoader]
+    },
+    resolve: {
+      extensions: ['', '.js', '.jsx']
+    },
+    output: output,
+
+    devServer: (options.useDevServer) ? {
+      contentBase: './dist',
+      hot: true
+    } : {},
+
+    devtool: (options.sourcemaps) ? 'cheap-module-eval-source-map' : '',
+    plugins: (options.useDevServer) ? [new webpack.HotModuleReplacementPlugin()] : []
+  };
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start:dev": "webpack-dev-server --port 9010 --config webpack-dev.config.js --progress --profile --colors",
     "build-css:dev": "node ./node_modules/gulp/bin/gulp.js",
     "test": "mocha --compilers js:babel-core/register --require ./test/test_helper.js 'test/**/*.@(js|jsx)'",
-    "test:watch": "npm run test -- --watch"
+    "test:watch": "npm run test -- --watch",
+    "build": "webpack --config webpack-production.config.js --progress --profile --colors"
   },
   "author": "Miro Nieminen <miro.nieminen@gmail.com>",
   "license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build-css:dev": "node ./node_modules/gulp/bin/gulp.js",
     "test": "mocha --compilers js:babel-core/register --require ./test/test_helper.js 'test/**/*.@(js|jsx)'",
     "test:watch": "npm run test -- --watch",
-    "build": "webpack --config webpack-production.config.js --progress --profile --colors"
+    "build": "webpack --config webpack-production.config.js --progress --profile --colors -p"
   },
   "author": "Miro Nieminen <miro.nieminen@gmail.com>",
   "license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start:dev": "webpack-dev-server --port 9010",
+    "start:dev": "webpack-dev-server --port 9010 --config webpack-dev.config.js --progress --profile --colors",
     "build-css:dev": "node ./node_modules/gulp/bin/gulp.js",
     "test": "mocha --compilers js:babel-core/register --require ./test/test_helper.js 'test/**/*.@(js|jsx)'",
     "test:watch": "npm run test -- --watch"

--- a/webpack-dev.config.js
+++ b/webpack-dev.config.js
@@ -1,0 +1,39 @@
+var webpack = require('webpack');
+
+module.exports = require('./make-webpack-config')({
+  entryItems: [
+    'webpack-dev-server/client?http://localhost:9010',
+    'webpack/hot/only-dev-server',
+  ],
+
+  loaderType: 'react-hot!babel',
+  outputFilename: 'bundle.js',
+  useDevServer: true,
+  sourcemaps: true
+
+
+
+  // module: {
+  //   loaders: [{
+  //     test: /\.jsx?$/,
+  //     exclude: /node_modules/,
+  //     loader: 'react-hot!babel'
+  //   }]
+  // },
+  // resolve: {
+  //   extensions: ['', '.js', '.jsx']
+  // },
+  // output: {
+  //   path: __dirname + '/dist',
+  //   publicPath: '/',
+  //   filename: 'bundle.js'
+  // },
+  // devServer: {
+  //   contentBase: './dist',
+  //   hot: true
+  // },
+  // devtool: 'cheap-module-eval-source-map',
+  // plugins: [
+  //   new webpack.HotModuleReplacementPlugin()
+  // ]
+});

--- a/webpack-dev.config.js
+++ b/webpack-dev.config.js
@@ -10,30 +10,4 @@ module.exports = require('./make-webpack-config')({
   outputFilename: 'bundle.js',
   useDevServer: true,
   sourcemaps: true
-
-
-
-  // module: {
-  //   loaders: [{
-  //     test: /\.jsx?$/,
-  //     exclude: /node_modules/,
-  //     loader: 'react-hot!babel'
-  //   }]
-  // },
-  // resolve: {
-  //   extensions: ['', '.js', '.jsx']
-  // },
-  // output: {
-  //   path: __dirname + '/dist',
-  //   publicPath: '/',
-  //   filename: 'bundle.js'
-  // },
-  // devServer: {
-  //   contentBase: './dist',
-  //   hot: true
-  // },
-  // devtool: 'cheap-module-eval-source-map',
-  // plugins: [
-  //   new webpack.HotModuleReplacementPlugin()
-  // ]
 });

--- a/webpack-production.config.js
+++ b/webpack-production.config.js
@@ -1,0 +1,9 @@
+// TODO: timestamp to bundle.js?
+module.exports = [
+  require('./make-webpack-config')({
+    entryItems: [],
+    loaderType: 'babel',
+    outputFilename: 'bundle.js',
+    minimize: true
+  })
+];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,35 +1,3 @@
-var webpack = require('webpack');
+module.exports = require('./make-webpack-config')({
 
-module.exports = {
-  entry: [
-    'webpack-dev-server/client?http://localhost:9010',
-    'webpack/hot/only-dev-server',
-    './src/index.jsx'
-  ],
-  module: {
-    loaders: [{
-      test: /\.jsx?$/,
-      exclude: /node_modules/,
-      loader: 'react-hot!babel'
-    }, {
-      test: /\.css$/,
-      loader: 'style!css!autoprefixer?browsers=last 2 versions'
-    }]
-  },
-  resolve: {
-    extensions: ['', '.js', '.jsx']
-  },
-  output: {
-    path: __dirname + '/dist',
-    publicPath: '/',
-    filename: 'bundle.js'
-  },
-  devServer: {
-    contentBase: './dist',
-    hot: true
-  },
-  devtool: 'cheap-module-eval-source-map',
-  plugins: [
-    new webpack.HotModuleReplacementPlugin()
-  ]
-};
+});


### PR DESCRIPTION
Create configurable webpack build flows.

![dog](https://cloud.githubusercontent.com/assets/4402654/12080696/f5bcdcfc-b26b-11e5-80b3-e2e959eda507.jpg)

The original development webpack config is from [teropa's redux guide's config](https://github.com/teropa/redux-voting-client/blob/master/webpack.config.js). This version is outcome of applying stuff from [react-starter](https://github.com/webpack/react-starter/blob/master/make-webpack-config.js) project from the webpack examples.

Development config should stay the same, but this PR adds the ability to create minimified production bundle from the app.
